### PR TITLE
Fix how we match cwd for status and accept

### DIFF
--- a/src/sandbox/changes/change_entries.rs
+++ b/src/sandbox/changes/change_entries.rs
@@ -276,7 +276,7 @@ impl ChangeEntries {
             })
             .collect();
 
-        let cwd_str = cwd.display().to_string();
+        let cwd_str = format!("{}/", cwd.display());
         ChangeEntries(
             self.0
                 .iter()


### PR DESCRIPTION
Problem: If your CWD was something like /foo/bar but there was change in /foo/bar-baz/some-file it would be listed because we were doing startswith cwd matching without a trailing `/`.