### PR TITLE
--mask support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -152,6 +152,14 @@ Set the log level to one of trace, debug, info, warn, or error. `-v` is shorthan
 Name of the sandbox, defaults to "sandbox". Executables run within the same sandbox
 name will be run in the same container.
 
+`--new`::
+Create a new sandbox with an auto-generated timestamp name. This is useful for
+creating ephemeral sandboxes for one-off tasks. Cannot be used with --name or --last.
+
+`--last`::
+Use the most recently created sandbox. This is useful for quickly returning to
+the last sandbox you were working in. Cannot be used with --name or --new.
+
 `--storage-dir=<STORAGE_DIR>`::
 Base storage directory for all sandboxes. Defaults to `~/.sandboxes/`
 
@@ -173,6 +181,20 @@ Examples:
     directory into the sandbox as read only.
   * `SANDBOX_BIND="my/protected/dir::ro" sandbox` works as well.
   * `SANDBOX_BIND="/dir1,/dir2" sandbox --bind=/dir3:/dir4:ro,/dir5` style combined mix and match bind mounting also works.
+
+`--mask[=<PATHS>]`::
+Mask paths by mounting tmpfs (for directories) or /dev/null (for files) to
+prevent access to sensitive data. This is useful for hiding configuration or
+credential directories from sandboxed processes.
+Examples:
+  * `--mask=~/.ssh` hides your SSH keys from the sandboxed process
+  * `--mask=/etc/passwd` masks the passwd file with /dev/null  
+  * `--mask=~/.aws,~/.config/gcloud` masks multiple paths
+  * `SANDBOX_MASK="~/.ssh,~/.aws" sandbox` works as well
+
+`--no-default-binds`::
+Disable default system bind mounts (e.g., /dev/fuse, D-Bus sockets, user directories).
+This is useful when you want complete control over what gets mounted into the sandbox.
 
 `--json`::
 Formats action output as a JSON blob. Does nothing for sandboxed commands

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -62,6 +62,16 @@ pub struct Args {
     )]
     pub bind: Option<Vec<String>>,
 
+    /// Mask paths by mounting tmpfs (for directories) or /dev/null (for files). Can be specified multiple times.
+    /// Multiple paths can be specified by using --mask multiple times or as a comma-separated list.
+    #[arg(
+        long,
+        global = true,
+        value_delimiter = ',',
+        action = clap::ArgAction::Append
+    )]
+    pub mask: Option<Vec<String>>,
+
     /// Disable default system bind mounts (e.g., /dev/fuse, D-Bus sockets, user directories)
     #[arg(long, global = true, action = clap::ArgAction::SetTrue)]
     pub no_default_binds: bool,

--- a/src/util/expand_tilde.rs
+++ b/src/util/expand_tilde.rs
@@ -1,0 +1,18 @@
+use std::path::{Path, PathBuf};
+use crate::util::resolve_uid_gid_home;
+use anyhow::Result;
+
+/// Expands a path that starts with ~ to use the user's home directory
+pub fn expand_tilde_path(path: &Path) -> Result<PathBuf> {
+    if let Some(path_str) = path.to_str() {
+        if path_str.starts_with('~') {
+            let uid_gid_home = resolve_uid_gid_home()?;
+            if path_str == "~" {
+                return Ok(uid_gid_home.home);
+            } else if let Some(rest) = path_str.strip_prefix("~/") {
+                return Ok(uid_gid_home.home.join(rest));
+            }
+        }
+    }
+    Ok(path.to_path_buf())
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,7 @@
 mod access;
 mod clone3;
 mod drop_privileges;
+mod expand_tilde;
 mod find_mount_point;
 mod get_running_sandbox_pid;
 mod lock_sandbox;
@@ -14,6 +15,7 @@ mod sync_and_drop_caches;
 pub use access::*;
 pub use clone3::*;
 pub use drop_privileges::*;
+pub use expand_tilde::*;
 pub use find_mount_point::*;
 pub use get_running_sandbox_pid::*;
 pub use lock_sandbox::*;

--- a/tests/isolated_test_stop_all.rs
+++ b/tests/isolated_test_stop_all.rs
@@ -10,6 +10,7 @@ use std::{io::Write, process::Command, thread::sleep, time::Duration};
  * tests that were running in parallel. */
 
 #[rstest]
+#[ignore = "Ignoring as this will stop non test sandboxes"]
 fn test_stop_all() -> Result<()> {
     let mut sandbox1 = sandbox();
     let mut sandbox2 = sandbox();

--- a/tests/isolated_test_stop_all_partial_fail.rs
+++ b/tests/isolated_test_stop_all_partial_fail.rs
@@ -10,6 +10,7 @@ use std::{process::Command, thread::sleep, time::Duration};
  * tests that were running in parallel. */
 
 #[rstest]
+#[ignore = "Problematic on dev machines with running sandboxes"]
 fn test_stop_all_partial_fail() -> Result<()> {
     let mut bad_sandbox = sandbox();
     bad_sandbox.run(&["true"])?;


### PR DESCRIPTION
Adds `--mask=<dir|file>` flag to hide the contents of directories or files within a sandbox