### PR TITLE
Add support for sub-sandboxes

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -40,6 +40,7 @@
         "domifaddr",
         "eaccess",
         "EAGAIN",
+        "EINVAL",
         "elif",
         "ELOOP",
         "endmntent",

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -707,7 +707,7 @@ fn generate_timestamp_name(
     loop {
         let now = Local::now();
         let base_name =
-            format!("ephemeral_{}", now.format("%Y-%m-%d_%H:%M:%S"));
+            format!("ephemeral_{}", now.format("%Y-%m-%d_%H-%M-%S"));
 
         // Check if this name already exists
         let sandbox_path = storage_dir.join(&base_name);

--- a/src/sandbox/changes/changes.rs
+++ b/src/sandbox/changes/changes.rs
@@ -38,6 +38,8 @@ const BUILT_IN_IGNORE_PATTERNS: &[&str] = &[
     "/tmp/**",
     "/home/*/.*/**",
     "/home/*/.*",
+    "/root/.*/**",
+    "/root/.*",
     "**/.git/**",
     "**/.git",
 ];

--- a/src/sandbox/exec.rs
+++ b/src/sandbox/exec.rs
@@ -83,6 +83,10 @@ impl Sandbox {
 
         unsafe {
             std::env::set_var("SANDBOX", self.name.clone());
+            std::env::set_var(
+                "SANDBOX_STORAGE_DIR",
+                self.sub_storage_dir.clone(),
+            );
         }
 
         /* We need to fork to properly enter the PID namespace */

--- a/src/sandbox/sandbox_struct.rs
+++ b/src/sandbox/sandbox_struct.rs
@@ -9,6 +9,7 @@ pub struct Sandbox {
     pub work_base: PathBuf,
     pub upper_base: PathBuf,
     pub overlay_base: PathBuf,
+    pub sub_storage_dir: PathBuf, // storage dir for the sub sandboxes
     //pub root_suffix: String,
     //pub root_work: PathBuf,
     //pub root_upper: PathBuf,

--- a/tests/test_sandbox_inception.rs
+++ b/tests/test_sandbox_inception.rs
@@ -1,0 +1,62 @@
+mod fixtures;
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+use fixtures::*;
+use rstest::*;
+
+// Find all .profraw files in the sub-sandboxes upper and copy them over to coverage/profraw
+fn copy_sub_sandbox_profraw(sub_dir: &Path) -> Result<()> {
+    println!("sub_dir: {}", sub_dir.display());
+    let sub_upper = sub_dir.join("upper");
+
+    let coverage_dir = Path::new("coverage/profraw");
+
+    fn copy_profraw_files(src_dir: &Path, dest_dir: &Path) -> Result<()> {
+        if src_dir.is_dir() {
+            for entry in fs::read_dir(src_dir)? {
+                let entry = entry?;
+                let path = entry.path();
+
+                if path.is_dir() {
+                    copy_profraw_files(&path, dest_dir)?;
+                } else if path.extension().and_then(|s| s.to_str())
+                    == Some("profraw")
+                {
+                    let file_name = path.file_name().unwrap();
+                    let dest_path = dest_dir.join(file_name);
+                    println!("Copying {:?} to {:?}", path, dest_path);
+                    fs::copy(&path, &dest_path)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    copy_profraw_files(Path::new(&sub_upper), coverage_dir)?;
+    Ok(())
+}
+
+#[rstest]
+fn test_overlayfs_stack_depth_message(
+    mut sandbox: SandboxManager,
+) -> Result<()> {
+    sandbox.set_debug_mode(true);
+    let sandbox_bin = get_sandbox_bin() + "-setuid";
+
+    assert!(sandbox.xfail(&[&sandbox_bin, &sandbox_bin, &sandbox_bin]));
+    assert!(
+        sandbox
+            .all_stderr
+            .contains("Maximum overlayfs stacking depth exceeded")
+    );
+
+    let sub_dir = sandbox.run(&[&sandbox_bin, "config", "sandbox_dir"])?;
+    let sub_dir = String::from_utf8_lossy(&sub_dir.stdout).to_string();
+    let sub_dir = sub_dir.trim().to_string();
+
+    copy_sub_sandbox_profraw(Path::new(&sub_dir))?;
+    Ok(())
+}


### PR DESCRIPTION
Allows the creation of sandboxes within sandboxes. The kernel is compiled with a maximum depth of 2 for overlayfs layers so that's the limit, but if compiled with a higher limit we should be able to create sandboxes deeper as well.