### PR TITLE
Validate settings haven't changed when entering a sandbox that is currently running

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.3.0"
 edition = "2024"
 include = ["src/**", "Cargo.toml", "clippy.toml", "*.lock", "tests/**", "Makefile"]
 
+[[bin]]
+name = "sandbox"
+path = "src/main.rs"
+
+[lib]
+name = "sandbox"
+path = "src/lib.rs"
+
 [lints.rust]
 
 [features]

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -1,9 +1,9 @@
 use super::impls::deserialize_level_filter;
 use anyhow::Result;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::PathBuf};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BindMount {
     pub source: PathBuf,
     pub target: PathBuf,
@@ -17,7 +17,7 @@ impl std::fmt::Display for BindMount {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum BindMountOptions {
     ReadWrite,
     ReadOnly,
@@ -40,7 +40,7 @@ impl std::str::FromStr for BindMountOptions {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, clap::ValueEnum)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, clap::ValueEnum)]
 pub enum Network {
     #[serde(rename = "none")]
     None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod actions;
+pub mod config;
+pub mod logger;
+pub mod sandbox;
+pub mod types;
+pub mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,12 @@
     clippy::used_underscore_items
 )]
 
-mod actions;
-mod config;
-mod logger;
-mod sandbox;
-mod types;
-mod util;
+pub mod actions;
+pub mod config;
+pub mod logger;
+pub mod sandbox;
+pub mod types;
+pub mod util;
 
 use anyhow::{Context, Result, anyhow};
 use clap::CommandFactory;

--- a/src/sandbox/exec.rs
+++ b/src/sandbox/exec.rs
@@ -85,7 +85,7 @@ impl Sandbox {
             std::env::set_var("SANDBOX", self.name.clone());
             std::env::set_var(
                 "SANDBOX_STORAGE_DIR",
-                self.sub_storage_dir.clone(),
+                self.data_storage_dir.clone(),
             );
         }
 

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -3,9 +3,11 @@ mod delete;
 mod exec;
 mod exists;
 mod get_or_create;
-mod mount_overlays;
+pub mod mount_overlays;
 mod sandbox_struct;
+mod settings;
 mod stop;
 mod unmount;
 
 pub use sandbox_struct::*;
+pub use settings::*;

--- a/src/sandbox/sandbox_struct.rs
+++ b/src/sandbox/sandbox_struct.rs
@@ -9,7 +9,7 @@ pub struct Sandbox {
     pub work_base: PathBuf,
     pub upper_base: PathBuf,
     pub overlay_base: PathBuf,
-    pub sub_storage_dir: PathBuf, // storage dir for the sub sandboxes
+    pub data_storage_dir: PathBuf, // storage dir for sandbox data and nested sandboxes
     //pub root_suffix: String,
     //pub root_work: PathBuf,
     //pub root_upper: PathBuf,

--- a/src/sandbox/settings.rs
+++ b/src/sandbox/settings.rs
@@ -1,0 +1,153 @@
+use crate::config::{BindMount, Config};
+use crate::sandbox::mount_overlays::MountHash;
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SandboxSettings {
+    pub version: String,
+    pub mounts: Vec<MountHash>,
+    pub network: crate::config::Network,
+    pub bind_mounts: Vec<BindMount>,
+}
+
+impl SandboxSettings {
+    pub fn from_config(config: &Config, mounts: &[MountHash]) -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            mounts: mounts.to_vec(),
+            network: config.net.clone(),
+            bind_mounts: config.bind_mounts.clone(),
+        }
+    }
+
+    /// Filter out implicit system bind mounts (like "data") for comparison purposes
+    /// Returns a sorted vector to ensure order-independent comparison
+    fn user_bind_mounts(&self) -> Vec<&BindMount> {
+        let mut binds: Vec<&BindMount> = self
+            .bind_mounts
+            .iter()
+            .filter(|bind| bind.argument != "data")
+            .collect();
+        // Sort by argument string to ensure consistent ordering
+        binds.sort_by(|a, b| a.argument.cmp(&b.argument));
+        binds
+    }
+
+    pub fn save_to_file(&self, path: &Path) -> Result<()> {
+        let settings_json = serde_json::to_string_pretty(self)
+            .context("Failed to serialize sandbox settings to JSON")?;
+        std::fs::write(path, settings_json).context(format!(
+            "Failed to write settings.json to {}",
+            path.display()
+        ))?;
+        Ok(())
+    }
+
+    pub fn load_from_file(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Err(anyhow!(
+                "Settings file does not exist: {}",
+                path.display()
+            ));
+        }
+        let settings_json = std::fs::read_to_string(path).context(format!(
+            "Failed to read settings.json from {}",
+            path.display()
+        ))?;
+        let settings: SandboxSettings = serde_json::from_str(&settings_json)
+            .context("Failed to parse settings.json")?;
+        Ok(settings)
+    }
+
+    pub fn validate_against_config(
+        &self,
+        config: &Config,
+        mounts: &[MountHash],
+    ) -> Result<()> {
+        let current_settings = Self::from_config(config, mounts);
+
+        if self.network != current_settings.network {
+            return Err(anyhow!(
+                "Network configuration has changed. Existing: {:?}, Current: {:?}. Please stop existing sandbox to change network settings.",
+                self.network,
+                current_settings.network
+            ));
+        }
+
+        if self.mounts != current_settings.mounts {
+            let mut error_msg =
+                String::from("Mount configuration has changed:\n");
+
+            // Find mounts that were removed
+            let removed_mounts: Vec<_> = self
+                .mounts
+                .iter()
+                .filter(|existing| !current_settings.mounts.contains(existing))
+                .collect();
+            if !removed_mounts.is_empty() {
+                error_msg.push_str("  Removed mounts:\n");
+                for mount in removed_mounts {
+                    error_msg.push_str(&format!("    - {}\n", mount.dir));
+                }
+            }
+
+            // Find mounts that were added
+            let added_mounts: Vec<_> = current_settings
+                .mounts
+                .iter()
+                .filter(|current| !self.mounts.contains(current))
+                .collect();
+            if !added_mounts.is_empty() {
+                error_msg.push_str("  Added mounts:\n");
+                for mount in added_mounts {
+                    error_msg.push_str(&format!("    - {}\n", mount.dir));
+                }
+            }
+
+            error_msg.push_str(
+                "Please stop the existing sandbox to change mount settings.",
+            );
+            return Err(anyhow!(error_msg));
+        }
+
+        // Compare only user-specified bind mounts (excluding implicit system mounts like "data")
+        let existing_user_binds = self.user_bind_mounts();
+        let current_user_binds = current_settings.user_bind_mounts();
+
+        if existing_user_binds != current_user_binds {
+            let mut error_msg =
+                String::from("Bind mount configuration has changed:\n");
+
+            // Find bind mounts that were removed
+            let removed_binds: Vec<_> = existing_user_binds
+                .iter()
+                .filter(|existing| !current_user_binds.contains(existing))
+                .collect();
+            if !removed_binds.is_empty() {
+                error_msg.push_str("  Removed bind mounts:\n");
+                for bind in &removed_binds {
+                    error_msg.push_str(&format!("    - {}\n", bind.argument));
+                }
+            }
+
+            // Find bind mounts that were added
+            let added_binds: Vec<_> = current_user_binds
+                .iter()
+                .filter(|current| !existing_user_binds.contains(current))
+                .collect();
+            if !added_binds.is_empty() {
+                error_msg.push_str("  Added bind mounts:\n");
+                for bind in &added_binds {
+                    error_msg.push_str(&format!("    - {}\n", bind.argument));
+                }
+            }
+
+            error_msg.push_str("Please stop the existing sandbox to change bind mount settings.");
+            return Err(anyhow!(error_msg));
+        }
+
+        Ok(())
+    }
+}

--- a/tests/ai_test_bind_mount_validation.rs
+++ b/tests/ai_test_bind_mount_validation.rs
@@ -1,0 +1,78 @@
+mod fixtures;
+
+use anyhow::Result;
+use fixtures::*;
+use rstest::*;
+use std::fs;
+
+#[rstest]
+fn test_bind_mount_validation_failure(mut sandbox: SandboxManager) -> Result<()> {
+    // Create temporary directories using the test filename pattern
+    let bind_source1 = sandbox.test_filename("bind-source-1");
+    let bind_source2 = sandbox.test_filename("bind-source-2");
+    fs::create_dir_all(&bind_source1)?;
+    fs::create_dir_all(&bind_source2)?;
+    fs::write(format!("{}/test.txt", bind_source1), "test content")?;
+    fs::write(format!("{}/test.txt", bind_source2), "different content")?;
+    
+    // Create and start sandbox with initial bind mount
+    let initial_bind = format!("{}:{}", bind_source1, "/mnt/test");
+    let _output1 = sandbox.run(&["--bind", &initial_bind, "echo", "initial setup"])?;
+    
+    // Try to run another command with a DIFFERENT bind mount - this should fail
+    let different_bind = format!("{}:{}", bind_source2, "/mnt/test");
+    
+    let result = sandbox.run(&["--bind", &different_bind, "echo", "should fail"]);
+    
+    // This should fail because bind mount configuration changed
+    assert!(result.is_err(), "Expected bind mount validation to fail when bind mounts change");
+    
+    // Check that the error message shows detailed changes
+    let error_output = format!("{}{}", sandbox.last_stderr, sandbox.last_stdout);
+    assert!(
+        error_output.contains("Bind mount configuration has changed") &&
+        error_output.contains("Removed bind mounts:") &&
+        error_output.contains("Added bind mounts:"),
+        "Expected detailed bind mount change information, got: {}",
+        error_output
+    );
+    
+    Ok(())
+}
+
+#[rstest] 
+fn test_bind_mount_validation_success(mut sandbox: SandboxManager) -> Result<()> {
+    // Create temporary directory using the test filename pattern
+    let bind_source = sandbox.test_filename("bind-source-same");
+    fs::create_dir_all(&bind_source)?;
+    fs::write(format!("{}/test.txt", bind_source), "test content")?;
+    
+    // Create and start sandbox with bind mount
+    let bind_mount = format!("{}:{}", bind_source, "/mnt/test");
+    let _output1 = sandbox.run(&["--bind", &bind_mount, "echo", "first command"])?;
+    
+    // Run another command with the SAME bind mount - this should succeed
+    let _output2 = sandbox.run(&["--bind", &bind_mount, "echo", "second command"])?;
+    
+    Ok(())
+}
+
+#[rstest]
+fn test_bind_mount_options_validation(mut sandbox: SandboxManager) -> Result<()> {
+    // Create temporary directory using the test filename pattern
+    let bind_source = sandbox.test_filename("bind-source-options");
+    fs::create_dir_all(&bind_source)?;
+    
+    // Start with read-write bind mount
+    let bind_rw = format!("{}:{}", bind_source, "/mnt/test");
+    let _output1 = sandbox.run(&["--bind", &bind_rw, "echo", "read-write"])?;
+    
+    // Try to change to read-only bind mount - this should fail
+    let bind_ro = format!("{}:{}:ro", bind_source, "/mnt/test");
+    let result = sandbox.run(&["--bind", &bind_ro, "echo", "read-only"]);
+    
+    // This should fail because bind mount options changed
+    assert!(result.is_err(), "Expected bind mount validation to fail when options change");
+    
+    Ok(())
+}

--- a/tests/ai_test_corrupted_settings.rs
+++ b/tests/ai_test_corrupted_settings.rs
@@ -1,0 +1,143 @@
+// Integration tests for corrupted sandbox settings handling
+// These tests verify error handling when sandbox settings files are corrupted or unreadable
+
+mod fixtures;
+
+use anyhow::Result;
+use fixtures::*;
+use rstest::*;
+use std::fs;
+
+#[rstest]
+fn test_get_or_create_with_corrupted_settings(mut sandbox: SandboxManager) -> Result<()> {
+    // First, create a working sandbox
+    let _output = sandbox.run(&["echo", "initial setup"])?;
+    
+    // Get the sandbox directory from the sandbox tool itself
+    let sandbox_dir = sandbox.dir()?;
+    let data_dir = sandbox_dir.join("data");
+    let settings_file = data_dir.join("settings.json");
+    
+    // Verify the sandbox was created and settings file exists
+    assert!(settings_file.exists(), "Settings file should exist after initial sandbox creation at {}", settings_file.display());
+    
+    // Corrupt the settings file by writing invalid JSON using sudo
+    let corrupt_json = "{ invalid json content that cannot be parsed }";
+    let write_cmd = std::process::Command::new("sudo")
+        .args(&["sh", "-c", &format!("echo '{}' > '{}'", corrupt_json, settings_file.display())])
+        .output()?;
+    
+    if !write_cmd.status.success() {
+        return Err(anyhow::anyhow!("Failed to corrupt settings file with sudo: {}", 
+                                   String::from_utf8_lossy(&write_cmd.stderr)));
+    }
+    
+    // Now try to run another command - this should trigger the error path in get_or_create
+    // because the existing sandbox has corrupted settings
+    let success = sandbox.pass(&["echo", "second command"]);
+    
+    // The command should fail due to corrupted settings
+    assert!(!success, "Command should fail due to corrupted settings file");
+    
+    // Check that the error message contains the expected text
+    let error_output = sandbox.last_stderr.clone();
+    
+    assert!(
+        error_output.contains("Failed to load existing sandbox settings") ||
+        error_output.contains("The sandbox may be corrupted") ||
+        error_output.contains("Failed to parse"),
+        "Expected error message about corrupted settings, got: {}",
+        error_output
+    );
+    
+    Ok(())
+}
+
+#[rstest]
+fn test_get_or_create_with_unreadable_settings(mut sandbox: SandboxManager) -> Result<()> {
+    // First, create a working sandbox
+    let _output = sandbox.run(&["echo", "initial setup"])?;
+    
+    // Get the sandbox directory from the sandbox tool itself
+    let sandbox_dir = sandbox.dir()?;
+    let data_dir = sandbox_dir.join("data");
+    let settings_file = data_dir.join("settings.json");
+    
+    // Verify the sandbox was created and settings file exists
+    assert!(settings_file.exists(), "Settings file should exist after initial sandbox creation");
+    
+    // Make the file unreadable by changing permissions (if we have permission to do so)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&settings_file)?.permissions();
+        perms.set_mode(0o000); // No read permissions
+        
+        // Only test this if we can actually change permissions (i.e., we're not root)
+        if fs::set_permissions(&settings_file, perms).is_ok() {
+            // Try to run another command - this should trigger the error path
+            let success = sandbox.pass(&["echo", "second command"]);
+            
+            // The command should fail due to permission error
+            assert!(!success, "Command should fail due to unreadable settings file");
+            
+            // Check that the error message contains the expected text
+            let error_output = sandbox.last_stderr.clone();
+            
+            assert!(
+                error_output.contains("Failed to load existing sandbox settings") ||
+                error_output.contains("The sandbox may be corrupted") ||
+                error_output.contains("Permission denied"),
+                "Expected error message about unreadable settings, got: {}",
+                error_output
+            );
+            
+            // Restore permissions for cleanup
+            let mut perms = fs::metadata(&settings_file)?.permissions();
+            perms.set_mode(0o644);
+            let _ = fs::set_permissions(&settings_file, perms);
+        }
+    }
+    
+    Ok(())
+}
+
+#[rstest]
+fn test_get_or_create_with_directory_as_settings_file(mut sandbox: SandboxManager) -> Result<()> {
+    // First, create a working sandbox
+    let _output = sandbox.run(&["echo", "initial setup"])?;
+    
+    // Get the sandbox directory from the sandbox tool itself  
+    let sandbox_dir = sandbox.dir()?;
+    let data_dir = sandbox_dir.join("data");
+    let settings_file = data_dir.join("settings.json");
+    
+    // Verify the sandbox was created and settings file exists
+    assert!(settings_file.exists(), "Settings file should exist after initial sandbox creation");
+    
+    // Remove the settings file and replace it with a directory
+    fs::remove_file(&settings_file)?;
+    fs::create_dir(&settings_file)?;
+    
+    // Verify the path now exists as a directory
+    assert!(settings_file.is_dir(), "Settings path should now be a directory");
+    
+    // Try to run another command - this should trigger the error path
+    let success = sandbox.pass(&["echo", "second command"]);
+    
+    // The command should fail
+    assert!(!success, "Command should fail when settings.json is a directory");
+    
+    // Check that the error message contains the expected text
+    let error_output = sandbox.last_stderr.clone();
+    
+    assert!(
+        error_output.contains("Failed to load existing sandbox settings") ||
+        error_output.contains("The sandbox may be corrupted") ||
+        error_output.contains("Is a directory"),
+        "Expected error message about directory as settings file, got: {}",
+        error_output
+    );
+    
+    Ok(())
+}

--- a/tests/ai_test_sandbox_settings.rs
+++ b/tests/ai_test_sandbox_settings.rs
@@ -1,0 +1,475 @@
+// Integration tests for SandboxSettings
+// These tests verify that settings serialization, validation, and file operations work correctly
+
+mod fixtures;
+
+use anyhow::Result;
+use fixtures::*;
+use rstest::*;
+use serde_json;
+use std::{fs, path::PathBuf};
+
+use ::sandbox::config::{BindMount, BindMountOptions, Network};
+use ::sandbox::sandbox::{SandboxSettings, mount_overlays::MountHash};
+use std::collections::HashMap;
+
+// Helper to create a minimal Config for testing
+fn create_test_config() -> ::sandbox::config::Config {
+    ::sandbox::config::Config {
+        log_level: log::LevelFilter::Info,
+        name: "test_sandbox".to_string(),
+        storage_dir: PathBuf::from("/tmp/test_storage"),
+        sandbox_dir: PathBuf::from("/tmp/test_sandbox"),
+        upper_cwd: PathBuf::from("/tmp/test_upper"),
+        overlay_cwd: PathBuf::from("/tmp/test_overlay"),
+        net: Network::None,
+        sources: HashMap::new(),
+        ignored: false,
+        bind_mounts: Vec::new(),
+        no_default_binds: false,
+        config_files: Vec::new(),
+    }
+}
+
+#[rstest]
+fn test_from_config() -> Result<()> {
+    let mut config = create_test_config();
+    config.net = Network::Host;
+    
+    let bind_mount = BindMount {
+        source: PathBuf::from("/source"),
+        target: PathBuf::from("/target"),
+        options: BindMountOptions::ReadOnly,
+        argument: "test_bind".to_string(),
+    };
+    config.bind_mounts = vec![bind_mount.clone()];
+
+    let mounts = vec![MountHash {
+        hash: "test_hash".to_string(),
+        dir: "/test/dir".to_string(),
+    }];
+
+    let settings = SandboxSettings::from_config(&config, &mounts);
+
+    assert_eq!(settings.version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(settings.mounts, mounts);
+    assert_eq!(settings.network, Network::Host);
+    assert_eq!(settings.bind_mounts, vec![bind_mount]);
+
+    Ok(())
+}
+
+#[rstest]
+fn test_user_bind_mounts_filtering_through_validation() -> Result<()> {
+    let mut config = create_test_config();
+    
+    let user_bind = BindMount {
+        source: PathBuf::from("/user/source"),
+        target: PathBuf::from("/user/target"),
+        options: BindMountOptions::ReadWrite,
+        argument: "user_bind".to_string(),
+    };
+    
+    let data_bind = BindMount {
+        source: PathBuf::from("/data/source"),
+        target: PathBuf::from("/data/target"),
+        options: BindMountOptions::ReadOnly,
+        argument: "data".to_string(),
+    };
+    
+    config.bind_mounts = vec![user_bind.clone(), data_bind.clone()];
+    let settings = SandboxSettings::from_config(&config, &[]);
+    
+    // Test that "data" bind mount is filtered out by trying validation with only data bind
+    let mut config_with_data_only = create_test_config();
+    config_with_data_only.bind_mounts = vec![data_bind];
+    
+    let result = settings.validate_against_config(&config_with_data_only, &[]);
+    
+    // Should fail because user_bind was removed, proving "data" bind is ignored
+    assert!(result.is_err());
+    let error_msg = result.unwrap_err().to_string();
+    assert!(error_msg.contains("Bind mount configuration has changed"));
+    assert!(error_msg.contains("user_bind"));
+    
+    Ok(())
+}
+
+#[rstest]
+fn test_save_and_load_from_file() -> Result<()> {
+    let sandbox = SandboxManager::new();
+    let test_dir = format!("generated-test-data/settings-{}", sandbox.name);
+    fs::create_dir_all(&test_dir)?;
+    let settings_path = PathBuf::from(format!("{}/settings.json", test_dir));
+
+    let mut config = create_test_config();
+    config.net = Network::None;
+    
+    let bind_mount = BindMount {
+        source: PathBuf::from("/test/source"),
+        target: PathBuf::from("/test/target"),
+        options: BindMountOptions::Mask,
+        argument: "test_mount".to_string(),
+    };
+    config.bind_mounts = vec![bind_mount.clone()];
+
+    let mounts = vec![
+        MountHash {
+            hash: "hash1".to_string(),
+            dir: "/dir1".to_string(),
+        },
+        MountHash {
+            hash: "hash2".to_string(),
+            dir: "/dir2".to_string(),
+        },
+    ];
+
+    let original_settings = SandboxSettings::from_config(&config, &mounts);
+
+    // Test save_to_file
+    original_settings.save_to_file(&settings_path)?;
+    
+    // Verify file was created and contains valid JSON
+    assert!(settings_path.exists());
+    let file_content = fs::read_to_string(&settings_path)?;
+    let _: serde_json::Value = serde_json::from_str(&file_content)?; // Verify it's valid JSON
+
+    // Test load_from_file
+    let loaded_settings = SandboxSettings::load_from_file(&settings_path)?;
+    
+    assert_eq!(loaded_settings, original_settings);
+    assert_eq!(loaded_settings.network, Network::None);
+    assert_eq!(loaded_settings.mounts.len(), 2);
+    assert_eq!(loaded_settings.bind_mounts.len(), 1);
+    assert_eq!(loaded_settings.bind_mounts[0].argument, "test_mount");
+
+    Ok(())
+}
+
+#[rstest]
+fn test_load_from_nonexistent_file() -> Result<()> {
+    let nonexistent_path = PathBuf::from("/nonexistent/path/settings.json");
+    
+    let result = SandboxSettings::load_from_file(&nonexistent_path);
+    
+    assert!(result.is_err());
+    let error_msg = result.unwrap_err().to_string();
+    assert!(error_msg.contains("Settings file does not exist"));
+    
+    Ok(())
+}
+
+#[rstest]
+fn test_load_from_invalid_json_file() -> Result<()> {
+    let sandbox = SandboxManager::new();
+    let test_dir = format!("generated-test-data/invalid-json-{}", sandbox.name);
+    fs::create_dir_all(&test_dir)?;
+    let settings_path = PathBuf::from(format!("{}/invalid.json", test_dir));
+
+    // Write invalid JSON
+    fs::write(&settings_path, "{ invalid json }")?;
+    
+    let result = SandboxSettings::load_from_file(&settings_path);
+    
+    assert!(result.is_err());
+    let error_msg = result.unwrap_err().to_string();
+    assert!(error_msg.contains("Failed to parse settings.json"));
+    
+    Ok(())
+}
+
+#[rstest]
+fn test_save_to_invalid_path() -> Result<()> {
+    let config = create_test_config();
+    let settings = SandboxSettings::from_config(&config, &[]);
+    
+    let invalid_path = PathBuf::from("/nonexistent/directory/settings.json");
+    
+    let result = settings.save_to_file(&invalid_path);
+    
+    assert!(result.is_err());
+    let error_msg = result.unwrap_err().to_string();
+    assert!(error_msg.contains("Failed to write settings.json"));
+    
+    Ok(())
+}
+
+#[rstest]
+fn test_validate_against_config_identical() -> Result<()> {
+    let mut config = create_test_config();
+    config.net = Network::Host;
+    
+    let bind_mount = BindMount {
+        source: PathBuf::from("/source"),
+        target: PathBuf::from("/target"),
+        options: BindMountOptions::ReadOnly,
+        argument: "test_bind".to_string(),
+    };
+    config.bind_mounts = vec![bind_mount];
+
+    let mounts = vec![MountHash {
+        hash: "test_hash".to_string(),
+        dir: "/test/dir".to_string(),
+    }];
+
+    let settings = SandboxSettings::from_config(&config, &mounts);
+    
+    // Validation against the same config should succeed
+    let result = settings.validate_against_config(&config, &mounts);
+    assert!(result.is_ok());
+
+    Ok(())
+}
+
+#[rstest]
+fn test_validate_against_config_network_change() -> Result<()> {
+    let mut original_config = create_test_config();
+    original_config.net = Network::Host;
+    
+    let mounts = vec![MountHash {
+        hash: "test_hash".to_string(),
+        dir: "/test/dir".to_string(),
+    }];
+
+    let settings = SandboxSettings::from_config(&original_config, &mounts);
+    
+    // Change network configuration
+    let mut new_config = original_config.clone();
+    new_config.net = Network::None;
+    
+    let result = settings.validate_against_config(&new_config, &mounts);
+    
+    assert!(result.is_err());
+    let error_msg = result.unwrap_err().to_string();
+    assert!(error_msg.contains("Network configuration has changed"));
+    assert!(error_msg.contains("Host"));
+    assert!(error_msg.contains("None"));
+    assert!(error_msg.contains("Please stop existing sandbox to change network settings"));
+
+    Ok(())
+}
+
+#[rstest]
+fn test_validate_against_config_mounts_removed() -> Result<()> {
+    let config = create_test_config();
+    
+    let original_mounts = vec![
+        MountHash {
+            hash: "hash1".to_string(),
+            dir: "/dir1".to_string(),
+        },
+        MountHash {
+            hash: "hash2".to_string(),
+            dir: "/dir2".to_string(),
+        },
+    ];
+
+    let settings = SandboxSettings::from_config(&config, &original_mounts);
+    
+    // Remove one mount
+    let new_mounts = vec![MountHash {
+        hash: "hash1".to_string(),
+        dir: "/dir1".to_string(),
+    }];
+    
+    let result = settings.validate_against_config(&config, &new_mounts);
+    
+    assert!(result.is_err());
+    let error_msg = result.unwrap_err().to_string();
+    assert!(error_msg.contains("Mount configuration has changed"));
+    assert!(error_msg.contains("Removed mounts"));
+    assert!(error_msg.contains("/dir2"));
+    assert!(error_msg.contains("Please stop the existing sandbox to change mount settings"));
+
+    Ok(())
+}
+
+#[rstest]
+fn test_validate_against_config_mounts_added() -> Result<()> {
+    let config = create_test_config();
+    
+    let original_mounts = vec![MountHash {
+        hash: "hash1".to_string(),
+        dir: "/dir1".to_string(),
+    }];
+
+    let settings = SandboxSettings::from_config(&config, &original_mounts);
+    
+    // Add another mount
+    let new_mounts = vec![
+        MountHash {
+            hash: "hash1".to_string(),
+            dir: "/dir1".to_string(),
+        },
+        MountHash {
+            hash: "hash2".to_string(),
+            dir: "/dir2".to_string(),
+        },
+    ];
+    
+    let result = settings.validate_against_config(&config, &new_mounts);
+    
+    assert!(result.is_err());
+    let error_msg = result.unwrap_err().to_string();
+    assert!(error_msg.contains("Mount configuration has changed"));
+    assert!(error_msg.contains("Added mounts"));
+    assert!(error_msg.contains("/dir2"));
+
+    Ok(())
+}
+
+#[rstest]
+fn test_validate_against_config_bind_mounts_removed() -> Result<()> {
+    let mut original_config = create_test_config();
+    
+    let bind1 = BindMount {
+        source: PathBuf::from("/source1"),
+        target: PathBuf::from("/target1"),
+        options: BindMountOptions::ReadOnly,
+        argument: "bind1".to_string(),
+    };
+    
+    let bind2 = BindMount {
+        source: PathBuf::from("/source2"),
+        target: PathBuf::from("/target2"),
+        options: BindMountOptions::ReadWrite,
+        argument: "bind2".to_string(),
+    };
+    
+    original_config.bind_mounts = vec![bind1.clone(), bind2];
+    
+    let settings = SandboxSettings::from_config(&original_config, &[]);
+    
+    // Remove one bind mount
+    let mut new_config = original_config.clone();
+    new_config.bind_mounts = vec![bind1];
+    
+    let result = settings.validate_against_config(&new_config, &[]);
+    
+    assert!(result.is_err());
+    let error_msg = result.unwrap_err().to_string();
+    assert!(error_msg.contains("Bind mount configuration has changed"));
+    assert!(error_msg.contains("Removed bind mounts"));
+    assert!(error_msg.contains("bind2"));
+    assert!(error_msg.contains("Please stop the existing sandbox to change bind mount settings"));
+
+    Ok(())
+}
+
+#[rstest]
+fn test_validate_against_config_bind_mounts_added() -> Result<()> {
+    let mut original_config = create_test_config();
+    
+    let bind1 = BindMount {
+        source: PathBuf::from("/source1"),
+        target: PathBuf::from("/target1"),
+        options: BindMountOptions::ReadOnly,
+        argument: "bind1".to_string(),
+    };
+    
+    original_config.bind_mounts = vec![bind1.clone()];
+    
+    let settings = SandboxSettings::from_config(&original_config, &[]);
+    
+    // Add another bind mount
+    let bind2 = BindMount {
+        source: PathBuf::from("/source2"),
+        target: PathBuf::from("/target2"),
+        options: BindMountOptions::Mask,
+        argument: "bind2".to_string(),
+    };
+    
+    let mut new_config = original_config.clone();
+    new_config.bind_mounts = vec![bind1, bind2];
+    
+    let result = settings.validate_against_config(&new_config, &[]);
+    
+    assert!(result.is_err());
+    let error_msg = result.unwrap_err().to_string();
+    assert!(error_msg.contains("Bind mount configuration has changed"));
+    assert!(error_msg.contains("Added bind mounts"));
+    assert!(error_msg.contains("bind2"));
+
+    Ok(())
+}
+
+#[rstest]
+fn test_validate_against_config_data_bind_mount_ignored() -> Result<()> {
+    let mut original_config = create_test_config();
+    
+    let user_bind = BindMount {
+        source: PathBuf::from("/user/source"),
+        target: PathBuf::from("/user/target"),
+        options: BindMountOptions::ReadOnly,
+        argument: "user_bind".to_string(),
+    };
+    
+    let data_bind = BindMount {
+        source: PathBuf::from("/data/source"),
+        target: PathBuf::from("/data/target"),
+        options: BindMountOptions::ReadWrite,
+        argument: "data".to_string(),
+    };
+    
+    original_config.bind_mounts = vec![user_bind.clone(), data_bind.clone()];
+    
+    let settings = SandboxSettings::from_config(&original_config, &[]);
+    
+    // New config has only the data bind mount (user bind removed)
+    let mut new_config = original_config.clone();
+    new_config.bind_mounts = vec![data_bind];
+    
+    let result = settings.validate_against_config(&new_config, &[]);
+    
+    // Should fail because user_bind was removed, even though data bind is ignored
+    assert!(result.is_err());
+    let error_msg = result.unwrap_err().to_string();
+    assert!(error_msg.contains("Bind mount configuration has changed"));
+    assert!(error_msg.contains("Removed bind mounts"));
+    assert!(error_msg.contains("user_bind"));
+
+    Ok(())
+}
+
+#[rstest]
+fn test_validate_against_config_multiple_changes() -> Result<()> {
+    let mut original_config = create_test_config();
+    
+    let mount1 = MountHash {
+        hash: "hash1".to_string(),
+        dir: "/dir1".to_string(),
+    };
+    
+    let mount2 = MountHash {
+        hash: "hash2".to_string(),
+        dir: "/dir2".to_string(),
+    };
+    
+    let bind1 = BindMount {
+        source: PathBuf::from("/bind1"),
+        target: PathBuf::from("/target1"),
+        options: BindMountOptions::ReadOnly,
+        argument: "bind1".to_string(),
+    };
+    
+    original_config.bind_mounts = vec![bind1.clone()];
+    original_config.net = Network::Host;
+    
+    let original_mounts = vec![mount1, mount2];
+    let settings = SandboxSettings::from_config(&original_config, &original_mounts);
+    
+    // Change everything
+    let mut new_config = original_config.clone();
+    new_config.net = Network::None; // This should be the first error
+    new_config.bind_mounts = vec![]; // Remove bind mount
+    let new_mounts = vec![]; // Remove all mounts
+    
+    let result = settings.validate_against_config(&new_config, &new_mounts);
+    
+    assert!(result.is_err());
+    let error_msg = result.unwrap_err().to_string();
+    // Should fail on network change first
+    assert!(error_msg.contains("Network configuration has changed"));
+
+    Ok(())
+}


### PR DESCRIPTION
With this patch you'll now receive an error if you are trying to change the network settings or bind mount settings, as opposed to just silently ignoring the changes and launching with whatever existing running settings there are.

Also changes the `sub` directory we were storing our potential sandboxes within sandboxes to `data` and puts the new more general `settings.json` file in there.